### PR TITLE
Fixes an 'unbound variable' error in bash

### DIFF
--- a/keyway_lib.sh
+++ b/keyway_lib.sh
@@ -17,7 +17,7 @@ acquire_lock_for() {
     check_execution "acquire lock"
     lock_log "Created $1 lock."
   else
-    lock_log "Cannot run $1 -- application locked by $lock_file."
+    lock_log "Cannot run $1 -- application locked."
     exit 1
   fi
 }


### PR DESCRIPTION
Removes the '$lock_file' variable on line 20, as it is not defined
anywhere, causing the library to fail with a "unbound variable" error
